### PR TITLE
Add onDragItemChangedPosition callback

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,6 +21,10 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:recyclerview-v7:25.3.1'
+    testCompile 'org.robolectric:robolectric:3.3.2'
+    testCompile 'org.mockito:mockito-core:2.7.22'
+    testCompile 'junit:junit:4.12'
+    testCompile 'com.squareup.assertj:assertj-android:1.0.0'
 }
 
 apply from: 'maven-publish.gradle'

--- a/library/src/main/java/com/woxthebox/draglistview/BoardView.java
+++ b/library/src/main/java/com/woxthebox/draglistview/BoardView.java
@@ -41,6 +41,8 @@ public class BoardView extends HorizontalScrollView implements AutoScroller.Auto
     public interface BoardListener {
         void onItemDragStarted(int column, int row);
 
+        void onDragItemChangedPosition(int oldColumn, int oldRow, int newColumn, int newRow);
+
         void onItemChangedColumn(int oldColumn, int newColumn);
 
         void onItemDragEnded(int fromColumn, int fromRow, int toColumn, int toRow);
@@ -66,6 +68,8 @@ public class BoardView extends HorizontalScrollView implements AutoScroller.Auto
     private int mDragStartRow;
     private boolean mHasLaidOut;
     private boolean mDragEnabled = true;
+    private Integer mLastDragColumn;
+    private Integer mLastDragRow;
 
     public BoardView(Context context) {
         super(context);
@@ -556,10 +560,20 @@ public class BoardView extends HorizontalScrollView implements AutoScroller.Auto
 
             @Override
             public void onDragging(int itemPosition, float x, float y) {
+                Integer column = getColumnOfList(recyclerView);
+                Integer row = itemPosition;
+                boolean positionChanged = !column.equals(mLastDragColumn) || !row.equals(mLastDragRow);
+                if (mBoardListener != null && positionChanged) {
+                    mLastDragColumn = column;
+                    mLastDragRow = row;
+                    mBoardListener.onDragItemChangedPosition(mDragStartColumn, mDragStartRow, getColumnOfList(recyclerView), row);
+                }
             }
 
             @Override
             public void onDragEnded(int newItemPosition) {
+                mLastDragColumn = null;
+                mLastDragRow = null;
                 if (mBoardListener != null) {
                     mBoardListener.onItemDragEnded(mDragStartColumn, mDragStartRow, getColumnOfList(recyclerView), newItemPosition);
                 }

--- a/library/src/main/java/com/woxthebox/draglistview/BoardView.java
+++ b/library/src/main/java/com/woxthebox/draglistview/BoardView.java
@@ -36,12 +36,14 @@ import android.widget.Scroller;
 
 import java.util.ArrayList;
 
+import static android.support.v7.widget.RecyclerView.NO_POSITION;
+
 public class BoardView extends HorizontalScrollView implements AutoScroller.AutoScrollListener {
 
     public interface BoardListener {
         void onItemDragStarted(int column, int row);
 
-        void onDragItemChangedPosition(int oldColumn, int oldRow, int newColumn, int newRow);
+        void onItemChangedPosition(int oldColumn, int oldRow, int newColumn, int newRow);
 
         void onItemChangedColumn(int oldColumn, int newColumn);
 
@@ -68,8 +70,8 @@ public class BoardView extends HorizontalScrollView implements AutoScroller.Auto
     private int mDragStartRow;
     private boolean mHasLaidOut;
     private boolean mDragEnabled = true;
-    private Integer mLastDragColumn;
-    private Integer mLastDragRow;
+    private int mLastDragColumn = NO_POSITION;
+    private int mLastDragRow = NO_POSITION;
 
     public BoardView(Context context) {
         super(context);
@@ -560,20 +562,20 @@ public class BoardView extends HorizontalScrollView implements AutoScroller.Auto
 
             @Override
             public void onDragging(int itemPosition, float x, float y) {
-                Integer column = getColumnOfList(recyclerView);
-                Integer row = itemPosition;
-                boolean positionChanged = !column.equals(mLastDragColumn) || !row.equals(mLastDragRow);
+                int column = getColumnOfList(recyclerView);
+                int row = itemPosition;
+                boolean positionChanged = column != mLastDragColumn || row != mLastDragRow;
                 if (mBoardListener != null && positionChanged) {
                     mLastDragColumn = column;
                     mLastDragRow = row;
-                    mBoardListener.onDragItemChangedPosition(mDragStartColumn, mDragStartRow, getColumnOfList(recyclerView), row);
+                    mBoardListener.onItemChangedPosition(mDragStartColumn, mDragStartRow, column, row);
                 }
             }
 
             @Override
             public void onDragEnded(int newItemPosition) {
-                mLastDragColumn = null;
-                mLastDragRow = null;
+                mLastDragColumn = NO_POSITION;
+                mLastDragRow = NO_POSITION;
                 if (mBoardListener != null) {
                     mBoardListener.onItemDragEnded(mDragStartColumn, mDragStartRow, getColumnOfList(recyclerView), newItemPosition);
                 }

--- a/library/src/test/java/com/woxthebox/draglistview/BoardViewTest.java
+++ b/library/src/test/java/com/woxthebox/draglistview/BoardViewTest.java
@@ -62,7 +62,7 @@ public class BoardViewTest {
 
         createColumnsAndDrag(adapter);
 
-        verify(boardListener).onDragItemChangedPosition(anyInt(), anyInt(), anyInt(), anyInt());
+        verify(boardListener).onItemChangedPosition(anyInt(), anyInt(), anyInt(), anyInt());
     }
 
     @Test
@@ -76,7 +76,7 @@ public class BoardViewTest {
         when(adapter.getPositionForItemId(firstItemId)).thenReturn(firstItemPosition);
         column.onDragging(0, 0);
 
-        verify(boardListener).onDragItemChangedPosition(0, 0, 0, firstItemPosition);
+        verify(boardListener).onItemChangedPosition(0, 0, 0, firstItemPosition);
     }
 
     private DragItemRecyclerView createColumnsAndDrag(DragItemAdapter adapter) {

--- a/library/src/test/java/com/woxthebox/draglistview/BoardViewTest.java
+++ b/library/src/test/java/com/woxthebox/draglistview/BoardViewTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017-Present Pivotal Software, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+
+package com.woxthebox.draglistview;
+
+import android.view.View;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertNull;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 25)
+public class BoardViewTest {
+    private BoardView subject;
+    private DragItemAdapter adapter;
+    private long firstItemId;
+
+    @Before
+    public void setUp() throws Exception {
+        adapter = mock(DragItemAdapter.class);
+        when(adapter.hasStableIds()).thenReturn(true);
+
+        subject = new BoardView(RuntimeEnvironment.application);
+        subject.onFinishInflate();
+    }
+
+    @Test
+    public void getRecyclerView_beforeAddingColumnList_returnsNull() {
+        assertNull(subject.getRecyclerView(0));
+    }
+
+    @Test
+    public void getRecyclerView_afterAddingColumnList_createsNewRecyclerView() {
+        subject.addColumnList(adapter, mock(View.class), false);
+
+        assertThat(subject.getRecyclerView(0)).isNotNull();
+    }
+
+    @Test
+    public void columnDragging_whenDraggingItem_callsOnDragItemChangedPosition() {
+        BoardView.BoardListener boardListener = mock(BoardView.BoardListener.class);
+        subject.setBoardListener(boardListener);
+
+        createColumnsAndDrag(adapter);
+
+        verify(boardListener).onDragItemChangedPosition(anyInt(), anyInt(), anyInt(), anyInt());
+    }
+
+    @Test
+    public void columnDragging_whenDraggingItem_whenItemPositionChanges_callsOnDragItemChangedPosition() {
+        int firstItemPosition = 3;
+        BoardView.BoardListener boardListener = mock(BoardView.BoardListener.class);
+        subject.setBoardListener(boardListener);
+        DragItemRecyclerView column = createColumnsAndDrag(adapter);
+        reset(boardListener);
+
+        when(adapter.getPositionForItemId(firstItemId)).thenReturn(firstItemPosition);
+        column.onDragging(0, 0);
+
+        verify(boardListener).onDragItemChangedPosition(0, 0, 0, firstItemPosition);
+    }
+
+    private DragItemRecyclerView createColumnsAndDrag(DragItemAdapter adapter) {
+        when(adapter.removeItem(anyInt())).thenReturn(mock(Object.class));
+        DragItemRecyclerView column = subject.addColumnList(adapter, null, false);
+        View view = mock(View.class);
+        when(view.getWidth()).thenReturn(1);
+        when(view.getHeight()).thenReturn(1);
+        firstItemId = 1L;
+        column.startDrag(view, firstItemId, 0.2f, 0.4f);
+
+        column.onDragging(0, 1);
+
+        return column;
+    }
+}

--- a/sample/src/main/java/com/woxthebox/draglistview/sample/BoardFragment.java
+++ b/sample/src/main/java/com/woxthebox/draglistview/sample/BoardFragment.java
@@ -72,6 +72,11 @@ public class BoardFragment extends Fragment {
             }
 
             @Override
+            public void onDragItemChangedPosition(int oldColumn, int oldRow, int newColumn, int newRow) {
+                Toast.makeText(mBoardView.getContext(), "Position changed - column: " + newColumn + " row: " + newRow, Toast.LENGTH_SHORT).show();
+            }
+
+            @Override
             public void onItemChangedColumn(int oldColumn, int newColumn) {
                 TextView itemCount1 = (TextView) mBoardView.getHeaderView(oldColumn).findViewById(R.id.item_count);
                 itemCount1.setText(Integer.toString(mBoardView.getAdapter(oldColumn).getItemCount()));

--- a/sample/src/main/java/com/woxthebox/draglistview/sample/BoardFragment.java
+++ b/sample/src/main/java/com/woxthebox/draglistview/sample/BoardFragment.java
@@ -72,7 +72,7 @@ public class BoardFragment extends Fragment {
             }
 
             @Override
-            public void onDragItemChangedPosition(int oldColumn, int oldRow, int newColumn, int newRow) {
+            public void onItemChangedPosition(int oldColumn, int oldRow, int newColumn, int newRow) {
                 Toast.makeText(mBoardView.getContext(), "Position changed - column: " + newColumn + " row: " + newRow, Toast.LENGTH_SHORT).show();
             }
 


### PR DESCRIPTION
Hi there!

We'd like to be notified when the item that is being dragged changes position so we've added the `onDragItemChangedPosition` callback to the `BoardListener` interface.


`onDragItemChangedPosition` will get called every time the item that is being dragged changes its position.

We've also added tests as a separate commit (including the use/addition of Robolectric).