### PR TITLE
Fix condition to prevent crash when callback not set

### DIFF
--- a/library/src/main/java/com/woxthebox/draglistview/BoardView.java
+++ b/library/src/main/java/com/woxthebox/draglistview/BoardView.java
@@ -275,7 +275,7 @@ public class BoardView extends HorizontalScrollView implements AutoScroller.Auto
 
             // Check if it is ok to drop the item in the new column first
             int newPosition = currentList.getDragPositionForY(getListTouchY(currentList));
-            if (mBoardListener == null || mBoardCallback.canDropItemAtPosition(mDragStartColumn, mDragStartRow, newColumn, newPosition)) {
+            if (mBoardCallback == null || mBoardCallback.canDropItemAtPosition(mDragStartColumn, mDragStartRow, newColumn, newPosition)) {
                 Object item = mCurrentRecyclerView.removeDragItemAndEnd();
                 if (item != null) {
                     mCurrentRecyclerView = currentList;


### PR DESCRIPTION
Thank you for a prompt merge of the previous PR!

In exploring with the new version, we discovered a crash when trying to drag an item across columns in a board view, introduced in v1.4.8.

I believe it's due to a type, and this PR has the intended condition, let us know otherwise.

Thanks again!
