### PR TITLE
 Added methods to expose RecyclerView's addItemDecoration methods

### DIFF
--- a/library/src/main/java/com/woxthebox/draglistview/DragListView.java
+++ b/library/src/main/java/com/woxthebox/draglistview/DragListView.java
@@ -293,6 +293,10 @@ public class DragListView extends FrameLayout {
         mRecyclerView.addItemDecoration(decor);
     }
 
+    public void addItemDecoration(RecyclerView.ItemDecoration decor, int index){
+        mRecyclerView.addItemDecoration(decor, index);
+    }
+
     /**
      * Set if items should not reorder automatically when dragging. If reorder is disabled, drop target
      * drawables can be set with {@link #setDropTargetDrawables} which will highlight the current item that

--- a/library/src/main/java/com/woxthebox/draglistview/DragListView.java
+++ b/library/src/main/java/com/woxthebox/draglistview/DragListView.java
@@ -289,6 +289,10 @@ public class DragListView extends FrameLayout {
         mRecyclerView.setScrollingEnabled(scrollingEnabled);
     }
 
+    public void addItemDecoration(RecyclerView.ItemDecoration decor){
+        mRecyclerView.addItemDecoration(decor);
+    }
+
     /**
      * Set if items should not reorder automatically when dragging. If reorder is disabled, drop target
      * drawables can be set with {@link #setDropTargetDrawables} which will highlight the current item that


### PR DESCRIPTION
An `ItemDecoration` allows an application to add drawing and layout offsets to item views. It is useful for drawing dividers between items. There are native methods on `RecyclerView` that already expose this functionality, so I have just created methods on `DragListView` to expose these methods. 